### PR TITLE
Address comments

### DIFF
--- a/include/nlohmann/detail/input/input_adapters.hpp
+++ b/include/nlohmann/detail/input/input_adapters.hpp
@@ -417,6 +417,9 @@ typename container_input_adapter_factory_impl::container_input_adapter_factory<C
     return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
 }
 
+// specialization for std::string
+using string_input_adapter = decltype(input_adapter(std::declval<std::string>()));
+
 #ifndef JSON_NO_IO
 // Special cases with fast paths
 inline file_input_adapter input_adapter(std::FILE* file)

--- a/include/nlohmann/detail/json_base_class_with_start_end_markers.hpp
+++ b/include/nlohmann/detail/json_base_class_with_start_end_markers.hpp
@@ -23,7 +23,6 @@ with reference to the parsed input.
 */
 struct json_base_class_with_start_end_markers
 {
-  public:
     size_t start_position = std::string::npos;
     size_t end_position = std::string::npos;
 };

--- a/single_include/nlohmann/json_fwd.hpp
+++ b/single_include/nlohmann/json_fwd.hpp
@@ -144,7 +144,6 @@ with reference to the parsed input.
 */
 struct json_base_class_with_start_end_markers
 {
-  public:
     size_t start_position = std::string::npos;
     size_t end_position = std::string::npos;
 };

--- a/tests/src/unit-class_parser.cpp
+++ b/tests/src/unit-class_parser.cpp
@@ -9,7 +9,6 @@
 #include "doctest_compatibility.h"
 
 #define JSON_TESTS_PRIVATE
-#include <nlohmann/detail/json_base_class_with_start_end_markers.hpp>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 using nlohmann::json;
@@ -324,7 +323,7 @@ void validate_generated_json_and_start_end_pos_helper(const std::string& origina
  *
  * This checks that whitespace around the nested object is included in the start and end positions of the root object.
  */
-void validate_start_end_pos_for_nested_obj_helper(std::string& nested_type_json_str, const std::string& root_type_json_str, const nlohmann::json_with_start_end_markers& expected_json, nlohmann::json_with_start_end_markers::parser_callback_t cb = nullptr)
+void validate_start_end_pos_for_nested_obj_helper(const std::string& nested_type_json_str, const std::string& root_type_json_str, const nlohmann::json_with_start_end_markers& expected_json, const nlohmann::json_with_start_end_markers::parser_callback_t& cb = nullptr)
 {
     nlohmann::json_with_start_end_markers j;
 
@@ -1767,8 +1766,8 @@ TEST_CASE("parser class")
         {
             // Create an object with spaces to test the start and end positions. Spaces will not be included in the
             // JSON object, however, the start and end positions should include the spaces from the input JSON string.
-            std::string nested_type_json_str =  R"({    "a":       1,"b"      : "test1"})";
-            std::string root_type_json_str =  R"({    "nested": )" + nested_type_json_str + R"(, "anotherValue": "test2"})";
+            const std::string nested_type_json_str =  R"({    "a":       1,"b"      : "test1"})";
+            const std::string root_type_json_str =  R"({    "nested": )" + nested_type_json_str + R"(, "anotherValue": "test2"})";
             auto expected = nlohmann::json_with_start_end_markers({{"nested", {{"a", 1}, {"b", "test1"}}}, {"anotherValue", "test2"}});
             auto filteredExpected = expected;
             filteredExpected["nested"].erase("a");
@@ -1778,8 +1777,8 @@ TEST_CASE("parser class")
 
         SECTION("for array")
         {
-            std::string nested_type_json_str =  R"(["a", "test", 45])";
-            std::string root_type_json_str =  R"({   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+            const std::string nested_type_json_str =  R"(["a", "test", 45])";
+            const std::string root_type_json_str =  R"({   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
             auto expected = nlohmann::json_with_start_end_markers({{"nested", {"a", "test", 45}}, {"anotherValue", "test"}});
             auto filteredExpected = expected;
             filteredExpected["nested"] = nlohmann::json_with_start_end_markers({"test", 45});
@@ -1788,8 +1787,8 @@ TEST_CASE("parser class")
 
         SECTION("for array with objects")
         {
-            std::string nested_type_json_str =  R"([{"a": 1, "b": "test"}, {"c": 2, "d": "test2"}])";
-            std::string root_type_json_str =  R"({   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+            const std::string nested_type_json_str =  R"([{"a": 1, "b": "test"}, {"c": 2, "d": "test2"}])";
+            const std::string root_type_json_str =  R"({   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
             auto expected = nlohmann::json_with_start_end_markers({{"nested", {{{"a", 1}, {"b", "test"}}, {{"c", 2}, {"d", "test2"}}}}, {"anotherValue", "test"}});
             auto filteredExpected = expected;
             filteredExpected["nested"][0].erase("a");
@@ -1797,15 +1796,15 @@ TEST_CASE("parser class")
 
             auto j = nlohmann::json_with_start_end_markers::parse(root_type_json_str);
             auto nested_array = j["nested"];
-            auto nested_obj = nested_array[0];
+            const auto& nested_obj = nested_array[0];
             CHECK(nested_type_json_str.substr(1, 21) == root_type_json_str.substr(nested_obj.start_position, nested_obj.end_position - nested_obj.start_position));
             CHECK(nested_type_json_str.substr(24, 22) == root_type_json_str.substr(nested_array[1].start_position, nested_array[1].end_position - nested_array[1].start_position));
         }
 
         SECTION("for two levels of nesting objects")
         {
-            std::string nested_type_json_str =  R"({"nested2": {"b": "test"}})";
-            std::string root_type_json_str =  R"({   "a": 2, "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+            const std::string nested_type_json_str =  R"({"nested2": {"b": "test"}})";
+            const std::string root_type_json_str =  R"({   "a": 2, "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
             auto expected = nlohmann::json_with_start_end_markers({{"a", 2}, {"nested", {{"nested2", {{"b", "test"}}}}}, {"anotherValue", "test"}});
             auto filteredExpected = expected;
             filteredExpected.erase("a");
@@ -1886,8 +1885,8 @@ TEST_CASE("parser class")
 
             SECTION("string type")
             {
-                std::string nested_type_json_str =  R"("test")";
-                std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+                const std::string nested_type_json_str =  R"("test")";
+                const std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
                 auto expected = nlohmann::json_with_start_end_markers({{"nested", "test"}, {"anotherValue", "test"}, {"a", 1}});
                 auto filteredExpected = expected;
                 filteredExpected.erase("a");
@@ -1896,8 +1895,8 @@ TEST_CASE("parser class")
 
             SECTION("number type")
             {
-                std::string nested_type_json_str =  R"(2)";
-                std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+                const std::string nested_type_json_str =  R"(2)";
+                const std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
                 auto expected = nlohmann::json_with_start_end_markers({{"nested", 2}, {"anotherValue", "test"}, {"a", 1}});
                 auto filteredExpected = expected;
                 filteredExpected.erase("a");
@@ -1906,8 +1905,8 @@ TEST_CASE("parser class")
 
             SECTION("boolean type")
             {
-                std::string nested_type_json_str =  R"(true)";
-                std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+                const std::string nested_type_json_str =  R"(true)";
+                const std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
                 auto expected = nlohmann::json_with_start_end_markers({{"nested", true}, {"anotherValue", "test"}, {"a", 1}});
                 auto filteredExpected = expected;
                 filteredExpected.erase("a");
@@ -1916,8 +1915,8 @@ TEST_CASE("parser class")
 
             SECTION("null type")
             {
-                std::string nested_type_json_str =  R"(null)";
-                std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
+                const std::string nested_type_json_str =  R"(null)";
+                const std::string root_type_json_str =  R"({ "a": 1,   "nested": )" + nested_type_json_str + R"(, "anotherValue": "test" })";
                 auto expected = nlohmann::json_with_start_end_markers({{"nested", nullptr}, {"anotherValue", "test"}, {"a", 1}});
                 auto filteredExpected = expected;
                 filteredExpected.erase("a");
@@ -1926,20 +1925,20 @@ TEST_CASE("parser class")
         }
         SECTION("with leading whitespace and newlines around root JSON")
         {
-            std::string initial_whitespace = R"(
+            const std::string initial_whitespace = R"(
                 
             )";
-            std::string nested_type_json_str = R"({
+            const std::string nested_type_json_str = R"({
                 "a": 1,
                 "nested": {
                     "b": "test"
                 },
                 "anotherValue": "test"
             })";
-            std::string end_whitespace = R"(
+            const std::string end_whitespace = R"(
                 
             )";
-            std::string root_type_json_str = initial_whitespace + nested_type_json_str + end_whitespace;
+            const std::string root_type_json_str = initial_whitespace + nested_type_json_str + end_whitespace;
 
             auto expected = nlohmann::json_with_start_end_markers({{"a", 1}, {"nested", {{"b", "test"}}}, {"anotherValue", "test"}});
 

--- a/tests/src/unit-deserialization.cpp
+++ b/tests/src/unit-deserialization.cpp
@@ -588,7 +588,7 @@ TEST_CASE("deserialization")
                 auto first = str.begin();
                 auto last = str.end();
                 json j;
-                json_sax_dom_parser<json, typename nlohmann::detail::container_input_adapter_factory_impl::container_input_adapter_factory<std::string>::adapter_type> sax(j, true);
+                json_sax_dom_parser<json, nlohmann::detail::string_input_adapter> sax(j, true);
 
                 CHECK(json::sax_parse(proxy(first), proxy(last), &sax,
                                       input_format_t::json, false));

--- a/tests/src/unit-disabled_exceptions.cpp
+++ b/tests/src/unit-disabled_exceptions.cpp
@@ -20,10 +20,10 @@ using json = nlohmann::json;
 // for #2824
 /////////////////////////////////////////////////////////////////////
 
-class sax_no_exception : public nlohmann::detail::json_sax_dom_parser<json, typename nlohmann::detail::container_input_adapter_factory_impl::container_input_adapter_factory<std::string>::adapter_type>
+class sax_no_exception : public nlohmann::detail::json_sax_dom_parser<json, nlohmann::detail::string_input_adapter>
 {
   public:
-    explicit sax_no_exception(json& j) : nlohmann::detail::json_sax_dom_parser<json, typename nlohmann::detail::container_input_adapter_factory_impl::container_input_adapter_factory<std::string>::adapter_type>(j, false) {}
+    explicit sax_no_exception(json& j) : nlohmann::detail::json_sax_dom_parser<json, nlohmann::detail::string_input_adapter>(j, false) {}
 
     static bool parse_error(std::size_t /*position*/, const std::string& /*last_token*/, const json::exception& ex)
     {


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header files `single_include/nlohmann/json.hpp` and `single_include/nlohmann/json_fwd.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for this kind of bug). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
